### PR TITLE
Handle the state parameter in callback URL.

### DIFF
--- a/Generic.php
+++ b/Generic.php
@@ -10,6 +10,10 @@ use OAuth\Common\Http\Uri\Uri;
  */
 class Generic extends AbstractOAuth2Base
 {
+    /** @inheritdoc */
+    public function needsStateParameterInAuthUrl() {
+        return true;
+    }
 
     /** @inheritdoc */
     public function getAuthorizationEndpoint()

--- a/Generic.php
+++ b/Generic.php
@@ -12,7 +12,8 @@ class Generic extends AbstractOAuth2Base
 {
     /** @inheritdoc */
     public function needsStateParameterInAuthUrl() {
-        return true;
+        $plugin = plugin_load('helper', 'oauthgeneric');
+        return 0 !== $plugin->getConf('needs-state');
     }
 
     /** @inheritdoc */

--- a/conf/default.php
+++ b/conf/default.php
@@ -11,6 +11,7 @@ $conf['tokenurl'] = '';
 $conf['userurl'] = '';
 $conf['authmethod'] = 0;
 $conf['scopes'] = '';
+$conf['needs-state'] = 0;
 
 $conf['json-user'] = '';
 $conf['json-name'] = '';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -11,6 +11,7 @@ $meta['tokenurl'] = array('string');
 $meta['userurl'] = array('string');
 $meta['authmethod'] = array('multichoice', '_choices' => [0, 1, 6, 2, 3, 4, 5]);
 $meta['scopes'] = array('array');
+$meta['needs-state'] = array('onoff');
 
 $meta['json-user'] = array('string');
 $meta['json-name'] = array('string');

--- a/lang/cs/settings.php
+++ b/lang/cs/settings.php
@@ -11,8 +11,8 @@ $lang['authurl'] = 'URL pro autentizaci';
 $lang['tokenurl'] = 'URL pro získání tokenu';
 $lang['userurl'] = 'Relativní URL pro získání uživatelských informací z API (musí vracet JSON data autentizovaného uživatele)';
 $lang['authmethod'] = 'Autorizační metoda pro získání uživatelských informací z API';
-$lang['scopes'] = 'Scopes to request (comma separated)';
 $lang['scopes'] = 'Požadovaná oprávnění (scopes, oddělená čárkou)';
+$lang['needs-state'] = 'Whether the provider needs and supplies a state parameter in the callback URL.';
 
 $lang['json-user'] = 'Objektová cesta k uživatelskému jménu (tečková notace)';
 $lang['json-name'] = 'Objektová cesta k celému jménu uživatele (tečkovánotace)';

--- a/lang/cs/settings.php
+++ b/lang/cs/settings.php
@@ -12,7 +12,7 @@ $lang['tokenurl'] = 'URL pro získání tokenu';
 $lang['userurl'] = 'Relativní URL pro získání uživatelských informací z API (musí vracet JSON data autentizovaného uživatele)';
 $lang['authmethod'] = 'Autorizační metoda pro získání uživatelských informací z API';
 $lang['scopes'] = 'Požadovaná oprávnění (scopes, oddělená čárkou)';
-$lang['needs-state'] = 'Whether the provider needs and supplies a state parameter in the callback URL.';
+$lang['needs-state'] = 'Poskytovatel potřebuje a poskytuje parametr pro přesměrování na callback URL';
 
 $lang['json-user'] = 'Objektová cesta k uživatelskému jménu (tečková notace)';
 $lang['json-name'] = 'Objektová cesta k celému jménu uživatele (tečkovánotace)';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -12,6 +12,7 @@ $lang['tokenurl'] = 'URL to the token endpoint';
 $lang['userurl'] = 'URL to the user info API endpoint (must return JSON about the authenticated user)';
 $lang['authmethod'] = 'Authorization method used when talking to the user API';
 $lang['scopes'] = 'Scopes to request (comma separated)';
+$lang['needs-state'] = 'The provider needs and supplies a state parameter in the callback URL.';
 
 $lang['json-user'] = 'Access to the username in dot notation';
 $lang['json-name'] = 'Access to the full name in dot notation';


### PR DESCRIPTION
This fixes login with certain providers, e.g. Authentik, that trigger the message
"OAuth: State not found in session, are you sure you stored it?"
This closes #6.

I only tested this against our Authentik instance, so I am not sure how it behaves with other providers that do not use the state parameter in the same way.